### PR TITLE
TEST: Change paths for data read-in

### DIFF
--- a/NEW_Analysis_fixed_plus_stan.R
+++ b/NEW_Analysis_fixed_plus_stan.R
@@ -30,7 +30,7 @@ a = ldply(
   .data = list.files(
 	  	pattern = ".txt"
   		, full.names = T
-  		, path = './Data_alpha'
+  		, path = './Baseball/baseballtojdata/Data_alpha'
   	)
   , .fun = check_before_read
   , .progress = 'text'
@@ -41,7 +41,7 @@ b = ldply(
 	.data = list.files(
 		pattern = ".txt"
 		, full.names = T
-		, path = './Data_delta'
+		, path = './Baseball/baseballtojdata/Data_delta'
 	)
 	, .fun = check_before_read
 	, .progress = 'text'


### PR DESCRIPTION
If the working directory is the overarching TOJ folder on my computer,
which includes both baseball and standard toj files, then I want to get
data a few folders downstream.
